### PR TITLE
Support dynamic tags (adding/deleting) and extra tag props

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -59,11 +59,10 @@ end
 -- @tparam table t The tag definition table for awful.tag.add
 -- @treturn table The created tag.
 function sharedtags.add(i, t)
-   local tag = awful.tag.add(t.name or i, {
-                              screen = (t.screen and t.screen <= capi.screen.count()) and t.screen or capi.screen.primary,
-                              layout = t.layout,
-                              sharedtagindex = i
-   })
+   t = awful.util.table.clone(t, false) -- shallow copy for modification
+   t.screen = (t.screen and t.screen <= capi.screen.count()) and t.screen or capi.screen.primary
+   t.sharedtagindex = i
+   local tag = awful.tag.add(t.name or i, t)
 
    -- If no tag is selected for this screen, then select this one.
    if not tag.screen.selected_tag then


### PR DESCRIPTION
I would like to be able to add or delete tags dynamically. For this I had to refactor the tag addition into `sharedtags.add` so that the `sharedtagindex` is not always relative to the array created in `new`, but can be specified manually. This does not change `sharedtags.new`, so this change should be backwards-compatible.

I also changed the tag creation so that extra tag props are propagated to `awful.tag.add`. Until now only `name`, `layout` and `screen` were propagated an all other were silently discarded.