### PR TITLE
fix tags being orphaned by screen disconnect

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -44,6 +44,13 @@ local sharedtags = {
 local function salvage(tag)
     -- The screen to move the orphaned tag to.
     local newscreen = capi.screen.primary
+    -- the primary screen may be the one that is being
+    -- removed, so try to find a different screen if possible.
+    for s in capi.screen do
+        if s ~= tag.screen then
+            newscreen = s
+        end
+    end
 
     -- Make sure the tag isn't selected when moved to the new screen.
     tag.selected = false


### PR DESCRIPTION
In the case where the primary screen is the one that
will be removed, the salvage function will not successfully
salvage the shared tag, resulting in being unable to retrieve
it in new screens.

Introduce additional fallback logic to find a suitable screen
to move to when salvaging.

I encountered this issue when docking my laptop, and have verified locally that the change resolves the issue.