### PR TITLE
Make salvage function public to be used by rc.lua

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -41,7 +41,7 @@ local sharedtags = {
 
 --- Attempts to salvage a tag when a screen is removed.
 -- @param tag The tag to salvage.
-local function salvage(tag)
+function salvage(tag)
     -- The screen to move the orphaned tag to.
     local newscreen = capi.screen.primary
     -- the primary screen may be the one that is being
@@ -58,7 +58,14 @@ local function salvage(tag)
     sharedtags.movetag(tag, newscreen)
 
     capi.screen[newscreen]:emit_signal("tag::history::update")
+
+    return newscreen
 end
+
+-- function sharedtags.salvage(tag)
+--     return salvage(tag)
+-- end
+
 
 --- Create one new tag with sharedtags metadata.
 -- This is mostly useful for setups with dynamic tag adding.

--- a/init.lua
+++ b/init.lua
@@ -62,10 +62,6 @@ function salvage(tag)
     return newscreen
 end
 
--- function sharedtags.salvage(tag)
---     return salvage(tag)
--- end
-
 
 --- Create one new tag with sharedtags metadata.
 -- This is mostly useful for setups with dynamic tag adding.


### PR DESCRIPTION
I was looking for a way to move tags between screens, and it turns out that the salvage function does exactly what i needed.

The only modification made is to remove the `local` keyword, as well as adding a return value to get the new screen. 

Example usage in `rc.lua`  below:
```lua
awful.key({ modkey, "Shift" } "m",
    function ()
        -- get tag where pointer resides
        local tag = awful.screen.focused().selected_tag
        -- move tag to other screen
        local newscreen = salvage(tag)
        -- make sure tag can be viewed
        sharedtags.viewonly(tag, newscreen)
        -- move pointer on the tag that moved
        awful.screen.focus(newscreen)
    end,
    {description = 'move tag to other screen', group = 'screen'})

```
Unfortunately i cannot test how this responds with multi monitor setups.