### PR TITLE
add a jumpto function to move focus to monitor containing a tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ Notes
 2. Because of constraints in the X server, *awesome* does not allow
    toggling clients on tags allocated to other screens. Having a client on
    multiple tags and moving one of the tags will cause the client to move as well.
-3. When selecting a tag on a different screen with `sharedtags.viewonly`, the tag is pulled to the current screen. To instead move focus to the other screen and focus the tag there, use `sharedtags.jumpto(tag)`. This can be used with a seperate bind that calls `sharedtags.movetag(tag, screen)` to directly move a tag to another screen.
+3. When selecting a tag on a different screen with `sharedtags.viewonly`, the tag is pulled to the current screen. To instead move focus to the other screen and view the tag there, use `sharedtags.jumpto(tag)`. This can be used with a seperate bind that calls `sharedtags.movetag(tag, screen)` to directly move a tag to another screen.
 
 API
 ---

--- a/README.md
+++ b/README.md
@@ -140,6 +140,7 @@ Notes
 2. Because of constraints in the X server, *awesome* does not allow
    toggling clients on tags allocated to other screens. Having a client on
    multiple tags and moving one of the tags will cause the client to move as well.
+3. When selecting a tag on a different screen with `sharedtags.viewonly`, the tag is pulled to the current screen. To instead move focus to the other screen and focus the tag there, use `sharedtags.jumpto(tag)`. This can be used with a seperate bind that calls `sharedtags.movetag(tag, screen)` to directly move a tag to another screen.
 
 API
 ---

--- a/init.lua
+++ b/init.lua
@@ -170,6 +170,11 @@ function sharedtags.viewonly(tag, screen)
     tag:view_only()
 end
 
+function sharedtags.jumpto(tag)
+    awful.screen.focus(tag.screen)
+    tag:view_only()
+end
+
 --- Toggle the specified tag on the specified screen.
 -- The tag will be selected if the screen changes, and toggled if it does not
 -- change the screen.

--- a/init.lua
+++ b/init.lua
@@ -170,6 +170,8 @@ function sharedtags.viewonly(tag, screen)
     tag:view_only()
 end
 
+--- Move focus to screen containing tag and view the tag on that screen
+-- @param tag The tag to jump to.
 function sharedtags.jumpto(tag)
     awful.screen.focus(tag.screen)
     tag:view_only()


### PR DESCRIPTION
When using a tag setup that has tags matched to monitors, it can be preferable to move focus to the monitor that contains a tag. This is in opposition to pulling the tag to the currently focused monitor, which `viewonly` does. 