### PR TITLE
Compatability with screen-dedicated tags

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -60,6 +60,18 @@ local function salvage(tag)
     capi.screen[newscreen]:emit_signal("tag::history::update")
 end
 
+-- Gets an index for ordering tags.
+-- @param tag The tag to get an index for
+-- @return An int representing the tags index in the tag list
+local function getidx(tag)
+    if tag.sharedtagindex then
+        -- Add arbitrarily large number to always be at the end
+        return tag.sharedtagindex + 10
+    else
+        return tag.index
+    end
+end
+
 --- Create one new tag with sharedtags metadata.
 -- This is mostly useful for setups with dynamic tag adding.
 -- @tparam number i The tag (global/shared) index
@@ -114,15 +126,6 @@ function sharedtags.new(def)
     end
 
     return tags
-end
-
-function getidx(tag)
-    if tag.sharedtagindex then
-        -- Add arbitrarily large number to always be at the end
-        return tag.sharedtagindex + 0
-    else
-        return tag.index
-    end
 end
 
 --- Move the specified tag to a new screen, if necessary.

--- a/init.lua
+++ b/init.lua
@@ -66,20 +66,20 @@ end
 -- @tparam table t The tag definition table for awful.tag.add
 -- @treturn table The created tag.
 function sharedtags.add(i, t)
-   t = awful.util.table.clone(t, false) -- shallow copy for modification
-   t.screen = (t.screen and t.screen <= capi.screen.count()) and t.screen or capi.screen.primary
-   t.sharedtagindex = i
-   local tag = awful.tag.add(t.name or i, t)
+    t = awful.util.table.clone(t, false) -- shallow copy for modification
+    t.screen = (t.screen and t.screen <= capi.screen.count()) and t.screen or capi.screen.primary
+    t.sharedtagindex = i
+    local tag = awful.tag.add(t.name or i, t)
 
-   -- If no tag is selected for this screen, then select this one.
-   if not tag.screen.selected_tag then
-      tag:view_only() -- Updates the history as well.
-   end
+    -- If no tag is selected for this screen, then select this one.
+    if not tag.screen.selected_tag then
+        tag:view_only() -- Updates the history as well.
+    end
 
-   -- Make sure to salvage the tag in case the screen disappears.
-   tag:connect_signal("request::screen", salvage)
+    -- Make sure to salvage the tag in case the screen disappears.
+    tag:connect_signal("request::screen", salvage)
 
-   return tag
+    return tag
 end
 
 --- Create new tag objects.
@@ -104,7 +104,7 @@ end
 function sharedtags.new(def)
     local tags = {}
 
-    for i,t in ipairs(def) do
+    for i, t in ipairs(def) do
         tags[i] = sharedtags.add(i, t)
 
         -- Create an alias between the index and the name.
@@ -114,6 +114,14 @@ function sharedtags.new(def)
     end
 
     return tags
+end
+
+function getidx(tag)
+    if tag.sharedtagindex then
+        return tag.sharedtagindex + 6
+    else
+        return tag.index
+    end
 end
 
 --- Move the specified tag to a new screen, if necessary.
@@ -148,10 +156,12 @@ function sharedtags.movetag(tag, screen)
 
         -- Also sort the tag in the taglist, by reapplying the index. This is just a nicety.
         local unpack = unpack or table.unpack
-        for _,s in ipairs({ screen, oldscreen or { tags = {} } }) do
+        for _, s in ipairs({ screen, oldscreen or { tags = {} } }) do
             local tags = { unpack(s.tags) } -- Copy
-            table.sort(tags, function(a, b) return a.sharedtagindex < b.sharedtagindex end)
-            for i,t in ipairs(tags) do
+            table.sort(tags, function(a, b)
+                return getidx(a) < getidx(b)
+            end)
+            for i, t in ipairs(tags) do
                 t.index = i
             end
         end

--- a/init.lua
+++ b/init.lua
@@ -66,20 +66,20 @@ end
 -- @tparam table t The tag definition table for awful.tag.add
 -- @treturn table The created tag.
 function sharedtags.add(i, t)
-   t = awful.util.table.clone(t, false) -- shallow copy for modification
-   t.screen = (t.screen and t.screen <= capi.screen.count()) and t.screen or capi.screen.primary
-   t.sharedtagindex = i
-   local tag = awful.tag.add(t.name or i, t)
+    t = awful.util.table.clone(t, false) -- shallow copy for modification
+    t.screen = (t.screen and t.screen <= capi.screen.count()) and t.screen or capi.screen.primary
+    t.sharedtagindex = i
+    local tag = awful.tag.add(t.name or i, t)
 
-   -- If no tag is selected for this screen, then select this one.
-   if not tag.screen.selected_tag then
-      tag:view_only() -- Updates the history as well.
-   end
+    -- If no tag is selected for this screen, then select this one.
+    if not tag.screen.selected_tag then
+        tag:view_only() -- Updates the history as well.
+    end
 
-   -- Make sure to salvage the tag in case the screen disappears.
-   tag:connect_signal("request::screen", salvage)
+    -- Make sure to salvage the tag in case the screen disappears.
+    tag:connect_signal("request::screen", salvage)
 
-   return tag
+    return tag
 end
 
 --- Create new tag objects.
@@ -104,7 +104,7 @@ end
 function sharedtags.new(def)
     local tags = {}
 
-    for i,t in ipairs(def) do
+    for i, t in ipairs(def) do
         tags[i] = sharedtags.add(i, t)
 
         -- Create an alias between the index and the name.
@@ -114,6 +114,15 @@ function sharedtags.new(def)
     end
 
     return tags
+end
+
+function getidx(tag)
+    if tag.sharedtagindex then
+        -- Arbitrarily large number to alway be at the end
+        return tag.sharedtagindex + 10
+    else
+        return tag.index
+    end
 end
 
 --- Move the specified tag to a new screen, if necessary.
@@ -148,10 +157,12 @@ function sharedtags.movetag(tag, screen)
 
         -- Also sort the tag in the taglist, by reapplying the index. This is just a nicety.
         local unpack = unpack or table.unpack
-        for _,s in ipairs({ screen, oldscreen or { tags = {} } }) do
+        for _, s in ipairs({ screen, oldscreen or { tags = {} } }) do
             local tags = { unpack(s.tags) } -- Copy
-            table.sort(tags, function(a, b) return a.sharedtagindex < b.sharedtagindex end)
-            for i,t in ipairs(tags) do
+            table.sort(tags, function(a, b)
+                return getidx(a) < getidx(b)
+            end)
+            for i, t in ipairs(tags) do
                 t.index = i
             end
         end

--- a/init.lua
+++ b/init.lua
@@ -118,8 +118,8 @@ end
 
 function getidx(tag)
     if tag.sharedtagindex then
-        -- Arbitrarily large number to alway be at the end
-        return tag.sharedtagindex + 10
+        -- Add arbitrarily large number to always be at the end
+        return tag.sharedtagindex + 0
     else
         return tag.index
     end


### PR DESCRIPTION
I wanted to have some tags that were shared and some that were dedicated to each screen, and I sort of just installed this alongside the default config. I got an error and fixed it, so I figured I'd push this here so it would be easier for other people to get working if they want to.

In the `sharedtags.movetag` method, when sorting the tags, it tries to compare the attribute `.sharedtagindex` but its getting the tags from the screens, so it includes tags not created through `sharedtags.new` meaning that attribute often isn't set. I added a small helper function that just returns `sharedtagindex` if set (+ an arbitrary int to always place shared tags on the end), and `index` otherwise. With that change everything works, and for people just using this normally nothing changes.

Also I think my linter messed with the formatting, but I can go back and change it if you want.